### PR TITLE
Add extra_output_columns parameter to cross validation

### DIFF
--- a/python/prophet/tests/test_diagnostics.py
+++ b/python/prophet/tests/test_diagnostics.py
@@ -101,6 +101,19 @@ class TestCrossValidation:
             _ = diagnostics.cross_validation(m, *args)
             # check single forecast function called expected number of times
             assert n_calls == forecasts
+    
+    @pytest.mark.parametrize("extra_output_columns", ["trend", ["trend"]])
+    def test_check_extra_output_columns_cross_validation(self, ts_short, backend, extra_output_columns):
+        m = Prophet(stan_backend=backend)
+        m.fit(ts_short)
+        df_cv = diagnostics.cross_validation(
+            m,
+            horizon="1 days",
+            period="1 days",
+            initial="140 days",
+            extra_output_columns=extra_output_columns
+        )
+        assert "trend" in df_cv.columns
 
     @pytest.mark.parametrize("growth", ["logistic", "flat"])
     def test_cross_validation_logistic_or_flat_growth(self, growth, ts_short, backend):


### PR DESCRIPTION
Recreated from original PR: https://github.com/facebook/prophet/pull/2486

The output of `cross_validation` currently does not return `trend`. In order to access it, this PR adds `extra_output_columns` as a new parameter to `cross_validation`. This way, the user is free to pass in `trend` as a String or as a list to `extra_output_columns` in order to retrieve the column in the output.